### PR TITLE
chore!: refactor and drop backwards compatiblity

### DIFF
--- a/Classes/RelativeTimeService.php
+++ b/Classes/RelativeTimeService.php
@@ -1,12 +1,14 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Smichaelsen\FluidViewHelperTimespan;
 
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
-class RelativeTimeUtility
+class RelativeTimeService
 {
-    public static function getRelativeTimeString(\DateInterval $interval, string $extensionName, string $precision, int $limitUnits = 99, bool $wrapInPreposition = false): string
+    public function getRelativeTimeString(\DateInterval $interval, string $extensionName, string $precision, int $limitUnits = 99, bool $wrapInPreposition = false): string
     {
         $messageParts = [];
         $timeunits = [
@@ -35,11 +37,11 @@ class RelativeTimeUtility
                 break;
             }
         }
-        if (count($messageParts) === 0) {
+        if ($messageParts === []) {
             if ($precision === 'day') {
                 // reference less than a day, but "day" is the precision
                 $key = 'today';
-            } elseif (self::dateIntervalIsNull($interval)) {
+            } elseif ($this->dateIntervalIsNull($interval)) {
                 // reference is just now
                 $key = 'now';
             } elseif ($interval->invert) {
@@ -60,14 +62,14 @@ class RelativeTimeUtility
         return $timeString;
     }
 
-    public static function createDateIntervalFromSeconds(int $seconds): \DateInterval
+    public function createDateIntervalFromSeconds(int $seconds): \DateInterval
     {
         $reference = new \DateTime();
         $reference->add(\DateInterval::createFromDateString($seconds . ' seconds'));
         return (new \DateTime())->diff($reference);
     }
 
-    protected static function dateIntervalIsNull(\DateInterval $dateInterval): bool
+    protected function dateIntervalIsNull(\DateInterval $dateInterval): bool
     {
         return (new \DateTime()) === (new \DateTime())->add($dateInterval);
     }

--- a/Classes/ViewHelpers/TimeSpanViewHelper.php
+++ b/Classes/ViewHelpers/TimeSpanViewHelper.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Smichaelsen\FluidViewHelperTimespan\ViewHelpers;
 
-use Smichaelsen\FluidViewHelperTimespan\RelativeTimeUtility;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use Smichaelsen\FluidViewHelperTimespan\RelativeTimeService;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -33,18 +33,21 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class TimeSpanViewHelper extends AbstractViewHelper
 {
-    public function initializeArguments()
+    public function __construct(
+        private readonly RelativeTimeService $relativeTimeService,
+    ) {}
+
+    public function initializeArguments(): void
     {
         parent::initializeArguments();
-        $this->registerArgument('extensionName', 'string', 'By default labels will be loaded from the request\'s current extension. Can be overwritten by this attribute.', FALSE);
-        $this->registerArgument('limitUnits', 'integer', 'Limit the amount of displayed units', FALSE, 99);
-        $this->registerArgument('precision', 'string', 'By default the timespan will be diplayed accurately down to the second. Provide "year", "month", "day", "hour" or "minute" to lower the precision.', FALSE, 'second');
-        $this->registerArgument('reference', \DateTime::class, 'The reference time, can also be passed as child content', FALSE);
+        $this->registerArgument('extensionName', 'string', 'Load labels from this extension', true);
+        $this->registerArgument('limitUnits', 'integer', 'Limit the amount of displayed units', false, 99);
+        $this->registerArgument('precision', 'string', 'By default the timespan will be diplayed accurately down to the second. Provide "year", "month", "day", "hour" or "minute" to lower the precision.', false, 'second');
+        $this->registerArgument('reference', \DateTime::class, 'The reference time, can also be passed as child content');
     }
 
     public function render(): string
     {
-        $this->arguments['extensionName'] = $this->arguments['extensionName'] ?: $this->controllerContext->getRequest()->getControllerExtensionName();
         $now = new \DateTime();
         /** @var \DateTime $reference */
         $reference = $this->arguments['reference'] ?: $this->renderChildren();
@@ -55,6 +58,12 @@ class TimeSpanViewHelper extends AbstractViewHelper
             return '';
         }
         $difference = $now->diff($reference);
-        return RelativeTimeUtility::getRelativeTimeString($difference, $this->arguments['extensionName'], $this->arguments['precision'], $this->arguments['limitUnits'], true);
+        return $this->relativeTimeService->getRelativeTimeString(
+            $difference,
+            $this->arguments['extensionName'],
+            $this->arguments['precision'],
+            $this->arguments['limitUnits'],
+            true
+        );
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,10 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  Smichaelsen\FluidViewHelperTimespan\:
+    resource: '../Classes/*'
+    exclude: '../Classes/Domain/Model/*'
+    public: true

--- a/README.md
+++ b/README.md
@@ -4,19 +4,17 @@ This package serves a ViewHelper for the TYPO3 templating engine Fluid.
 
 ## Installation
 
-1. Add to your `composer.json`:
+1. Composer:
 
-`"require": { "smichaelsen/fluid-viewhelper-timespan": "dev-master" }`
+`composer require smichaelsen/fluid-viewhelper-timespan`
 
 2. Copy the file `Resources/Private/Language/locallang.xlf` to your TYPO3 extension (or merge the contents if you already have a locallang file) and adjust/translate the labels.
-
-No installation in the TYPO3 extension manager needed, because it is no TYPO3 extension!
 
 ## Usage example
 
     <html data-namespace-typo3-fluid="true" xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers" xmlns:vhts="http://typo3.org/ns/Smichaelsen/FluidViewHelperTimespan/ViewHelpers">
 
-      User {user.name} registered {user.crdate -> vhts:timeSpan(limitUnits:'2')}.
+      User {user.name} registered {user.crdate -> vhts:timeSpan(limitUnits:'2', extensionName: 'MyExtension')}.
 
     </html>
 

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,19 @@
 {
 	"name": "smichaelsen/fluid-viewhelper-timespan",
+	"type": "typo3-cms-extension",
 	"description": "TimeSpanViewHelper for Fluid",
 	"require": {
-		"php": "^7.4 || ^8.0",
-		"typo3/cms-core": "^10.4 || ^11.5 || ^12.4"
+		"php": "^8.0",
+		"typo3/cms-core": "^12.4 || ^13.4"
 	},
 	"autoload": {
 		"psr-4": {
 			"Smichaelsen\\FluidViewHelperTimespan\\": "Classes/"
+		}
+	},
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "fluid_viewhelper_timespan"
 		}
 	}
 }


### PR DESCRIPTION
* for better DI and testability `RelativeTimeUtility` was transformed into a mockable service class `RelativeTimeService`
* passing an `extensionName` to the ViewHelper is now mandatory
* dropped support for PHP 7.4 and TYPO3 v10 and v11
* added support for TYPO3 v13