### PR TITLE
ci: raise phpstan level to 4

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 
-      - name: Run PHPStan level 2
+      - name: Run PHPStan level 4
         run: composer phpstan
 
   phpstan-lowest:
@@ -41,5 +41,5 @@ jobs:
       - name: Install lowest dependencies
         run: composer update --prefer-lowest --prefer-dist --no-interaction --no-progress
 
-      - name: Run PHPStan level 2
+      - name: Run PHPStan level 4
         run: composer phpstan

--- a/Classes/ViewHelpers/TimeSpanViewHelper.php
+++ b/Classes/ViewHelpers/TimeSpanViewHelper.php
@@ -49,7 +49,6 @@ class TimeSpanViewHelper extends AbstractViewHelper
     public function render(): string
     {
         $now = new \DateTime();
-        /** @var \DateTime $reference */
         $reference = $this->arguments['reference'] ?: $this->renderChildren();
         if (is_numeric($reference)) {
             $reference = \DateTime::createFromFormat('U', $reference);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,4 @@
 parameters:
-  level: 2
+  level: 4
   paths:
     - Classes


### PR DESCRIPTION
Remove incorrect `@var \DateTime` PHPDoc from TimeSpanViewHelper::render() which falsely narrowed the type and caused two level-4 errors (impossible is_numeric() check and always-true instanceof check). Removing it lets phpstan infer mixed, making both guards valid.

Raise phpstan.neon from level 2 to 4 and update CI workflow step names.